### PR TITLE
Polaris: Automated PR: Update mysql:mysql-connector-java:8.0.12 to 8.0.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.12</version>
+            <version>8.0.33</version>
         </dependency>
 
         <!-- 处理json数据 -->


### PR DESCRIPTION
### *high:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2018-3258](https://nvd.nist.gov/vuln/detail/CVE-2018-3258) *(high)*: MySQL Connectors is vulnerable to privilege escalation due to flaws in the component that facilitates communication between applications written in the Java programming language and a MySQL server. A remote authenticated attacker could exploit this vulnerablility to gain greater privileges by providing the application with crafted input.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2019-2692](https://nvd.nist.gov/vuln/detail/CVE-2019-2692) *(medium)*: A process takeover vulnerability has been discovered in MySQL Connectors. The weakness was discovered within the Java Database Connectivity (JDBC) protocol utilized by the system. An attacker with high level privileges and additional human interaction can takeover and compromise the MySQL connectors.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[BDSA-2019-3759](https://openhub.net/vulnerabilities/bdsa/BDSA-2019-3759) *(medium)*: MySQL Connector is vulnerable to information disclosure due to how clients handle a server's response to a connection request. An attacker could read files on a victim's underlying system by tricking them into connecting to a malicious server.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2020-2934](https://nvd.nist.gov/vuln/detail/CVE-2020-2934) *(medium)*: It was discovered that with low success rate MySQL Connectors could be compromised by a remote unauthenticated attacker. This requires user interaction to successfully exploit.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2020-2875](https://nvd.nist.gov/vuln/detail/CVE-2020-2875) *(medium)*: It was discovered that MySQL Connectors could be used to compromise other systems. An attack that exploits this would be carried by a remote unauthenticated attacker and have a low success rate.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2021-2471](https://nvd.nist.gov/vuln/detail/CVE-2021-2471) *(medium)*: Oracle MySQL connectors contains a denial-of-service (DoS) vulnerability. An authenticated attacker can take advantage of this to cause a frequently repeatable crash of MySQL connectors, as well as unauthorized access to critical data or complete access to all MySQL connectors accessible data.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2021-2471](https://nvd.nist.gov/vuln/detail/CVE-2021-2471) *(medium)*: Oracle MySQL connectors contains a denial-of-service (DoS) vulnerability. An authenticated attacker can take advantage of this to cause a frequently repeatable crash of MySQL connectors, as well as unauthorized access to critical data or complete access to all MySQL connectors accessible data.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2022-21363](https://nvd.nist.gov/vuln/detail/CVE-2022-21363) *(medium)*: An unspecified vulnerability has been discovered in MySQL Connectors `Connector/J` component. An attacker with high level privileges and network access via multiple protocols could exploit this in order to takeover MySQL connectors.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2023-21971](https://nvd.nist.gov/vuln/detail/CVE-2023-21971) *(medium)*: Oracle MySQL Connectors contains a vulnerability that allows a unauthorized modification of data as well as denial-of-service (DoS). An authenticated attacker can take advantage of this to cause a frequently repeatable crash of MySQL server. This could also allow an attacker unauthorized update, insert or delete access to some of MySQL Server accessible data.

### *high:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2023-22102](https://nvd.nist.gov/vuln/detail/CVE-2023-22102) *(high)*: Oracle MySQL Connectors contains a vulnerability within the `Connector/J` component. A remote unauthenticated attacker could exploit this vulnerability via multiple protocols in order to disclose sensitive information, damage the application's integrity or cause a denial-of-service (DoS) condition.

### *high:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2023-22102](https://nvd.nist.gov/vuln/detail/CVE-2023-22102) *(high)*: Oracle MySQL Connectors contains a vulnerability within the `Connector/J` component. A remote unauthenticated attacker could exploit this vulnerability via multiple protocols in order to disclose sensitive information, damage the application's integrity or cause a denial-of-service (DoS) condition.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2019-10219](https://nvd.nist.gov/vuln/detail/CVE-2019-10219) *(medium)*: A vulnerability was found in Hibernate-Validator. The SafeHtml validator annotation fails to properly sanitize payloads consisting of potentially malicious code in HTML comments and instructions. This vulnerability can result in an XSS attack.

### *high:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2019-2435](https://nvd.nist.gov/vuln/detail/CVE-2019-2435) *(high)*: Vulnerability in the MySQL Connectors component of Oracle MySQL (subcomponent: Connector/Python). Supported versions that are affected are 8.0.13 and prior and 2.1.8 and prior. Easily exploitable vulnerability allows unauthenticated attacker with network access via TLS to compromise MySQL Connectors. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in unauthorized creation, deletion or modification access to critical data or all MySQL Connectors accessible data as well as unauthorized access to critical data or complete access to all MySQL Connectors accessible data. CVSS 3.0 Base Score 8.1 (Confidentiality and Integrity impacts). CVSS Vector: (CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N).

### *high:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2020-1967](https://nvd.nist.gov/vuln/detail/CVE-2020-1967) *(high)*: Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the "signature_algorithms_cert" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2021-3449](https://nvd.nist.gov/vuln/detail/CVE-2021-3449) *(medium)*: An OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).

### *high:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2021-3450](https://nvd.nist.gov/vuln/detail/CVE-2021-3450) *(high)*: The X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a "purpose" has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named "purpose" values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).

### *critical:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2021-3711](https://nvd.nist.gov/vuln/detail/CVE-2021-3711) *(critical)*: In order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the "out" parameter can be NULL and, on exit, the "outlen" parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the "out" parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).

### *high:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2021-3712](https://nvd.nist.gov/vuln/detail/CVE-2021-3712) *(high)*: ASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL's own "d2i" functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the "data" and "length" fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the "data" field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).

### *high:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2021-44531](https://nvd.nist.gov/vuln/detail/CVE-2021-44531) *(high)*: Accepting arbitrary Subject Alternative Name (SAN) types, unless a PKI is specifically defined to use a particular SAN type, can result in bypassing name-constrained intermediates. Node.js < 12.22.9, < 14.18.3, < 16.13.2, and < 17.3.1 was accepting URI SAN types, which PKIs are often not defined to use. Additionally, when a protocol allows URI SANs, Node.js did not match the URI correctly.Versions of Node.js with the fix for this disable the URI SAN type when checking a certificate against a hostname. This behavior can be reverted through the --security-revert command-line option.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2021-44532](https://nvd.nist.gov/vuln/detail/CVE-2021-44532) *(medium)*: Node.js < 12.22.9, < 14.18.3, < 16.13.2, and < 17.3.1 converts SANs (Subject Alternative Names) to a string format. It uses this string to check peer certificates against hostnames when validating connections. The string format was subject to an injection vulnerability when name constraints were used within a certificate chain, allowing the bypass of these name constraints.Versions of Node.js with the fix for this escape SANs containing the problematic characters in order to prevent the injection. This behavior can be reverted through the --security-revert command-line option.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2021-44532](https://nvd.nist.gov/vuln/detail/CVE-2021-44532) *(medium)*: Node.js < 12.22.9, < 14.18.3, < 16.13.2, and < 17.3.1 converts SANs (Subject Alternative Names) to a string format. It uses this string to check peer certificates against hostnames when validating connections. The string format was subject to an injection vulnerability when name constraints were used within a certificate chain, allowing the bypass of these name constraints.Versions of Node.js with the fix for this escape SANs containing the problematic characters in order to prevent the injection. This behavior can be reverted through the --security-revert command-line option.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2021-44533](https://nvd.nist.gov/vuln/detail/CVE-2021-44533) *(medium)*: Node.js < 12.22.9, < 14.18.3, < 16.13.2, and < 17.3.1 did not handle multi-value Relative Distinguished Names correctly. Attackers could craft certificate subjects containing a single-value Relative Distinguished Name that would be interpreted as a multi-value Relative Distinguished Name, for example, in order to inject a Common Name that would allow bypassing the certificate subject verification.Affected versions of Node.js that do not accept multi-value Relative Distinguished Names and are thus not vulnerable to such attacks themselves. However, third-party code that uses node's ambiguous presentation of certificate subjects may be vulnerable.

### *high:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2022-21824](https://nvd.nist.gov/vuln/detail/CVE-2022-21824) *(high)*: Due to the formatting logic of the "console.table()" function it was not safe to allow user controlled input to be passed to the "properties" parameter while simultaneously passing a plain object with at least one property as the first parameter, which could be "__proto__". The prototype pollution has very limited control, in that it only allows an empty string to be assigned to numerical keys of the object prototype.Node.js >= 12.22.9, >= 14.18.3, >= 16.13.2, and >= 17.3.1 use a null protoype for the object these properties are being assigned to.

### *high:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2022-21824](https://nvd.nist.gov/vuln/detail/CVE-2022-21824) *(high)*: Due to the formatting logic of the "console.table()" function it was not safe to allow user controlled input to be passed to the "properties" parameter while simultaneously passing a plain object with at least one property as the first parameter, which could be "__proto__". The prototype pollution has very limited control, in that it only allows an empty string to be assigned to numerical keys of the object prototype.Node.js >= 12.22.9, >= 14.18.3, >= 16.13.2, and >= 17.3.1 use a null protoype for the object these properties are being assigned to.

### *medium:* Update mysql:mysql-connector-java:8.0.12 to 8.0.33 
[CVE-2024-21262](https://nvd.nist.gov/vuln/detail/CVE-2024-21262) *(medium)*: Vulnerability in the MySQL Connectors product of Oracle MySQL (component: Connector/ODBC).  Supported versions that are affected are 9.0.0 and prior. Easily exploitable vulnerability allows unauthenticated attacker with network access via multiple protocols to compromise MySQL Connectors.  Successful attacks of this vulnerability can result in  unauthorized update, insert or delete access to some of MySQL Connectors accessible data and unauthorized ability to cause a partial denial of service (partial DOS) of MySQL Connectors. CVSS 3.1 Base Score 6.5 (Integrity and Availability impacts).  CVSS Vector: (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L).

[Click Here To See More Details On Server](https://cdev.dev.polaris.blackduck.com/portfolio/portfolios/682aa270-732e-4bc4-a210-bed993d70e9a/portfolio-items/14994c5d-42c8-40f1-aa81-861cf1b92819/projects/61c5eff7-2172-4c61-a839-5e377eb979dc/components/4d3a8ebc-28fd-4b71-86f1-48a630c6d7aa)